### PR TITLE
Fix stale portals added to manager and menus not focused

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -536,7 +536,7 @@ class Menu extends React.Component<Props, State> {
       >
         {this.isCoordinate(anchor) ? null : anchor}
         {rendered ? (
-          <Portal>
+          <Portal isFocused={visible}>
             <TouchableWithoutFeedback
               accessibilityLabel={overlayAccessibilityLabel}
               accessibilityRole="button"

--- a/src/components/Portal/PortalConsumer.tsx
+++ b/src/components/Portal/PortalConsumer.tsx
@@ -23,11 +23,15 @@ export default class PortalConsumer extends React.Component<Props> {
   componentDidUpdate() {
     this.checkManager();
 
-    this.props.manager.update(
-      this.key,
-      this.props.children,
-      this.props.isFocused
-    );
+    // Because of the delay in componentDidMount, componentDidUpdate
+    // can run before a key is set causing corrupt data in the manager.
+    if (this.key) {
+      this.props.manager.update(
+        this.key,
+        this.props.children,
+        this.props.isFocused
+      );
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Fixes stale entries going into portal manager.

**PortalConsumer issues**
Current in some situations `componentDidUpdate` runs before the last line of `componentDidMount` because `componentDidMount` is `async` and has a `await Promise.resolve()` thrown in. This causes issues because `this.props.manager.update` can be called before a `key` is created for the `PortalConsumer` which leads to portals with `undefined` key hanging around in the manager. That breaks the `isFocused` setting of portals because if the `undefined` portal is active, it'll never be removed and the focus state will never be reset.